### PR TITLE
feat: Add 'db' script for json-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "db": "json-server --watch db.json --port 3300"
   },
   "eslintConfig": {
     "extends": [

--- a/src/components/card/CardStyles.ts
+++ b/src/components/card/CardStyles.ts
@@ -21,11 +21,12 @@ export const CardImage = styled.div<{ background: string }>`
   background-image: url(${({ background }) => background});
   border-top-left-radius: 15px;
   border-top-right-radius: 15px;
-  background-size: cover;
+  background-size: contain;
   background-position: center;
   background-repeat: no-repeat;
   height: 30vh;
   max-height: 210px;
+  margin: 10px;
 `;
 
 export const CardTextWrapper = styled.div`

--- a/src/components/memberCard/CardStyles.ts
+++ b/src/components/memberCard/CardStyles.ts
@@ -21,11 +21,12 @@ export const CardImage = styled.div<{ background: string }>`
   background-image: url(${({ background }) => background});
   border-top-left-radius: 15px;
   border-top-right-radius: 15px;
-  background-size: cover;
+  background-size: contain;
   background-position: center;
   background-repeat: no-repeat;
   height: 30vh;
   max-height: 210px;
+  margin: 10px;
 `;
 
 export const CardTextWrapper = styled.div`

--- a/src/components/post/index.tsx
+++ b/src/components/post/index.tsx
@@ -16,7 +16,6 @@ interface Props extends PostType {
 }
 
 const Post: React.FC<Props> = (props) => {
-  console.log(props);
   const firstImage = props.image[0];
   const [modalOpen, setModalOpen] = useState(false);
   const [showInfo, setShowInfo] = useState(false);

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -30,7 +30,9 @@ export const api = async (
 ) => {
   const options = fetchOptions(method, body);
 
-  const url = `http://localhost:3004/${endpoint}`;
+  const port = process.env.REACT_APP_PORT || 3300;
+
+  const url = `http://localhost:${port}/${endpoint}`;
   let res = await fetch(url, options);
 
   if (!res.ok) {

--- a/src/services/write.service.ts
+++ b/src/services/write.service.ts
@@ -3,14 +3,7 @@ import { Post } from "../types/post.interface";
 import { api, deleteTempImageFromDb, uploadApi } from "./api.service";
 
 export const getAllLocation = async (): Promise<Location[]> => {
-  const res = await fetch(`http://localhost:3004/location`);
-
-  if (!res.ok) {
-    throw new Error("エラーが発生しました。");
-  }
-
-  const locations = await res.json();
-
+  const locations = await api("GET", "location");
   return locations;
 };
 
@@ -64,13 +57,7 @@ export const postPost = async (
 };
 
 export const getEditPost = async (userId: number): Promise<Post> => {
-  const res = await fetch(`http://localhost:3004/post/${userId}`);
-
-  if (!res.ok) {
-    throw new Error("エラーが発生しました。");
-  }
-
-  const post = await res.json();
+  const post = await api("GET", `post?userId=${userId}`);
   return post;
 };
 
@@ -88,15 +75,5 @@ export const uploadEditPost = async (
     area: area,
   };
 
-  const res = await fetch(`http://localhost:3004/post/${postId}`, {
-    method: "PATCH",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(editPost),
-  });
-
-  if (!res.ok) {
-    throw new Error("エラーが発生しました。");
-  }
+  await api("PATCH", `post/${postId}`, editPost);
 };


### PR DESCRIPTION
# feat
- `package.json` > `scripts` 에 json-server 3300 포트로 띄우는 script 추가
- `src/services/api.service.ts` > `api` 함수의 fetch 포트를 3300 으로 설정

# refactor
- `src/services/write.service.ts` > `getAllLocation`, `getEditPost`, `uploadEditPost` 함수들을 `src/services/api.service.ts` > `api` 사용하도록 수정

# style
- `src/components/card/CardStyles.ts` > `CardImage`, `src/components/memberCard/CardStyles.ts` > `CardImage` 컴포넌트에 margin 추가, backgraound-size 속성을 contain 으로 변경